### PR TITLE
PropertyEntry focus on property

### DIFF
--- a/src/main/java/io/github/nbcss/wynnlib/mixins/MouseInvoker.java
+++ b/src/main/java/io/github/nbcss/wynnlib/mixins/MouseInvoker.java
@@ -1,0 +1,11 @@
+package io.github.nbcss.wynnlib.mixins;
+
+import net.minecraft.client.Mouse;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Invoker;
+
+@Mixin(Mouse.class)
+public interface MouseInvoker {
+    @Invoker
+    void callOnCursorPos(long window, double x, double y);
+}

--- a/src/main/resources/wynnlib.mixins.json
+++ b/src/main/resources/wynnlib.mixins.json
@@ -6,6 +6,7 @@
     "defaultRequire": 1
   },
   "mixins": [
+    "MouseInvoker",
     "NBTPrinterMixin",
     "NetworkMixin",
     "analysis.InventoryAnalysisMixin",


### PR DESCRIPTION
This pr fixes the two issues with focusing on property on click with my client, namely that the cursor isn't placed correctly and that the old tooltip is still rendered after the cursor is moved. It also attempts to simplify the math, i.e. there should be no dependence on the current scroll to find the new scroll.

 This should be tested on other clients too.